### PR TITLE
Support mkr plugin install

### DIFF
--- a/.goxc.json
+++ b/.goxc.json
@@ -1,0 +1,18 @@
+{
+    "ArtifactsDest": "dist",
+    "Tasks": [
+        "clean-destination",
+        "xc",
+        "archive-zip",
+        "rmbin"
+    ],
+    "TaskSettings": {
+        "archive-zip": {
+            "include-top-level-dir": "windows darwin linux",
+            "platforms": "windows darwin linux"
+        }
+    },
+    "Arch": "386 amd64",
+    "Os": "linux darwin windows",
+    "ConfigVersion": "0.9"
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+setup:
+	go get \
+		github.com/laher/goxc \
+		github.com/tcnksm/ghr \
+		github.com/golang/lint/golint
+	go get -d -t ./...
+
+lint: setup
+	go vet ./...
+	golint -set_exit_status ./...
+
+.PHONY: setup lint

--- a/script/release
+++ b/script/release
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Usage: GITHUB_TOKEN=... script/release
+
+set -e
+latest_tag=$(git describe --abbrev=0 --tags)
+goxc
+ghr -u ayumu83s -r mackerel-plugin-nasne $latest_tag dist/snapshot/


### PR DESCRIPTION
Thank you for providing useful mackerel plugin! Recently, plugin users can install third party's plugins (like this plugin) with [mkr](https://github.com/mackerelio/mkr).

- https://mackerel.io/ja/docs/entry/advanced/install-plugin-by-mkr
- https://mackerel.io/ja/docs/entry/advanced/make-plugin-corresponding-to-installer

This pull request enables us to install this plugin via `mkr plugin install ayumu83s/mackerel-plugin-nasne`

---

プラグイン便利に使わせてもらっています。最近、mackerelのコマンドラインツールであるmkrがプラグインのインストールに対応したので、mackerel-plugin-nasneも`mkr plugin install`でインストールできるようにしてみました。もしよろしければ対応いただけるとうれしいです。